### PR TITLE
Multiple fixes

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -91,7 +91,7 @@ func main() {
 
 	cert := certificate(details)
 
-	id, err := ship.UniqueID(details.BrandName, "eebus")
+	id, err := ship.UniqueIDWithProtectedID(details.BrandName, "eebus")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	cert := certificate(details)
 
-	id, err := ship.UniqueID(details.BrandName, "eebus")
+	id, err := ship.UniqueIDWithProtectedID(details.BrandName, "eebus")
 	if err != nil {
 		panic(err)
 	}

--- a/ship/connection.go
+++ b/ship/connection.go
@@ -53,9 +53,7 @@ func (c *connection) IsConnectionClosed() bool {
 }
 
 func (c *connection) Read() (json.RawMessage, error) {
-	timer := time.NewTimer(600 * time.Second)
-
-	msg, err := c.t.ReadMessage(timer.C)
+	msg, err := c.t.ReadMessage(nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Fix client and server example
- Don’t use a timeout for reading spine messages
  Receiving no SPINE messages is absolutely valid scenario and there should be no timeout to check this.
  In fact this is the cause why the Elli chargers are disconnected after a 10 minute connection
- Remove (non) "Elli" workaround